### PR TITLE
chore: Only push to docker image on merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,7 @@ on:
         type: boolean
         default: true
   push:
-    branches:
-      - "**"
+    branches: [main]
     tags:
       - "v*"
   pull_request_target:


### PR DESCRIPTION
## Problem
The docker metadata tags are only added on merge events, causing the build-and-push step to fail when pushing to a feature branch.

## Solution
- Only run workflow on push events to `main` branch
- Only enable docker `push` on merge events

### Security

- [ ] Change has security implications (if so, ping the security team)
